### PR TITLE
Авто определение типа аппарата и все режимы полета ardupilot для Крыла и Мультиротора

### DIFF
--- a/src/mavsdk/core/flight_mode.cpp
+++ b/src/mavsdk/core/flight_mode.cpp
@@ -72,8 +72,37 @@ FlightMode to_flight_mode_from_ardupilot_copter_mode(uint32_t custom_mode)
             return FlightMode::Offboard;
         case ardupilot::CopterMode::Stabilize:
             return FlightMode::Stabilized;
+
+        case ardupilot::CopterMode::Circle:
+            return FlightMode::Circle;
+        case ardupilot::CopterMode::Drift:
+            return FlightMode::Drift;
+        case ardupilot::CopterMode::Sport:
+            return FlightMode::Sport;
+        case ardupilot::CopterMode::Flip:
+            return FlightMode::Flip;
+        case ardupilot::CopterMode::AutoTune:
+            return FlightMode::Autotune;
+        case ardupilot::CopterMode::Break:
+            return FlightMode::Brake;
+        case ardupilot::CopterMode::Throw:
+            return FlightMode::Throw;
+        case ardupilot::CopterMode::AvoidAdbs:
+            return FlightMode::AvoidADSB;
+        case ardupilot::CopterMode::GuidedNoGps:
+            return FlightMode::GuidedNoGPS;
+        case ardupilot::CopterMode::SmartRtl:
+            return FlightMode::SmartRTL;
+        case ardupilot::CopterMode::Zigzag:
+            return FlightMode::ZigZag;
+        case ardupilot::CopterMode::SystemId:
+            return FlightMode::SystemId;
+        case ardupilot::CopterMode::AutoRotate:
+            return FlightMode::AutoRotate;
+        case ardupilot::CopterMode::Turtle:
+            return FlightMode::Turtle;
+
         case ardupilot::CopterMode::Unknown:
-            return FlightMode::Unknown;
         default:
             return FlightMode::Unknown;
     }
@@ -94,7 +123,7 @@ FlightMode to_flight_mode_from_ardupilot_plane_mode(uint32_t custom_mode)
         case ardupilot::PlaneMode::Fbwb:
             return FlightMode::FBWB;
         case ardupilot::PlaneMode::Guided:
-            return FlightMode::Guided;
+            return FlightMode::Offboard;
         case ardupilot::PlaneMode::Loiter:
             return FlightMode::Hold;
         case ardupilot::PlaneMode::Rtl:
@@ -109,8 +138,29 @@ FlightMode to_flight_mode_from_ardupilot_plane_mode(uint32_t custom_mode)
             return FlightMode::QLand;
         case ardupilot::PlaneMode::QRtl:
             return FlightMode::QRtl;
+
+        case ardupilot::PlaneMode::Circle:
+            return FlightMode::Circle;
+        case ardupilot::PlaneMode::Training:
+            return FlightMode::Training;
+        case ardupilot::PlaneMode::Cruise:
+            return FlightMode::Cruise;
+        case ardupilot::PlaneMode::Takeoff:
+            return FlightMode::Takeoff;
+        case ardupilot::PlaneMode::AvoidAdsb:
+            return FlightMode::AvoidADSB;
+        case ardupilot::PlaneMode::Initializing:
+            return FlightMode::Initializing;
+        case ardupilot::PlaneMode::QHover:
+            return FlightMode::QHover;
+        case ardupilot::PlaneMode::QAutotune:
+            return FlightMode::QAutotune;
+        case ardupilot::PlaneMode::QAcro:
+            return FlightMode::QAcro;
+        case ardupilot::PlaneMode::Thermal:
+            return FlightMode::Thermal;
+
         case ardupilot::PlaneMode::Unknown:
-            return FlightMode::Unknown;
         default:
             return FlightMode::Unknown;
     }

--- a/src/mavsdk/core/flight_mode.h
+++ b/src/mavsdk/core/flight_mode.h
@@ -11,7 +11,6 @@ enum class FlightMode {
     FBWA,
     FBWB,
     Autotune,
-    Guided,
     Ready,
     Takeoff,
     Hold,
@@ -29,7 +28,29 @@ enum class FlightMode {
     QStabilize,
     QLoiter,
     QLand,
-    QRtl
+    QRtl,
+
+    Circle,
+    Drift,
+    Sport,
+    Flip,
+    Brake,
+    Throw,
+    AvoidADSB,
+    GuidedNoGPS,
+    SmartRTL,
+    ZigZag,
+    SystemId,
+    AutoRotate,
+    Turtle,
+
+    Training,
+    Cruise,
+    Initializing,
+    QHover,
+    QAutotune,
+    QAcro,
+    Thermal
 };
 
 FlightMode

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -101,12 +101,43 @@ public:
         Acro, /**< @brief In 'Acro' mode. */
         Stabilized, /**< @brief In 'Stabilize' mode. */
         Rattitude, /**< @brief In 'Rattitude' mode. */
+
         QStabilize,
         QLoiter,
         QLand,
         QRtl,
         FBWA,
-        FBWB
+        FBWB,
+
+        AutoTune,
+        Circle,
+        Drift,
+        Sport,
+        Flip,
+        Brake,
+        Throw,
+        AvoidADSB,
+        GuidedNoGPS,
+        SmartRTL,
+        ZigZag,
+        SystemId,
+        AutoRotate,
+        Turtle,
+
+        Training,
+        Cruise,
+        Initializing,
+        QHover,
+        QAutotune,
+        QAcro,
+        Thermal
+    };
+
+    enum class VehicleType {
+        Unknown,
+        Plane,
+        Multirotor,
+        VTOL
     };
 
     /**
@@ -1462,6 +1493,12 @@ public:
      * @return One FlightMode update.
      */
     FlightMode flight_mode() const;
+
+    using VehicleTypeCallback = std::function<void(VehicleType)>;
+    using VehicleTypeHandle = Handle<VehicleType>;
+    VehicleTypeHandle subscribe_vehicle_type(const VehicleTypeCallback& callback);
+    void unsubscribe_vehicle_type(VehicleTypeHandle handle);
+    VehicleType vehicle_type() const;
 
     /**
      * @brief Callback type for subscribe_health.

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -295,6 +295,21 @@ Telemetry::FlightMode Telemetry::flight_mode() const
     return _impl->flight_mode();
 }
 
+Telemetry::VehicleTypeHandle Telemetry::subscribe_vehicle_type(const VehicleTypeCallback& callback)
+{
+    return _impl->subscribe_vehicle_type(callback);
+}
+
+void Telemetry::unsubscribe_vehicle_type(VehicleTypeHandle handle)
+{
+    _impl->unsubscribe_vehicle_type(handle);
+}
+
+Telemetry::VehicleType Telemetry::vehicle_type() const
+{
+    return _impl->vehicle_type();
+}
+
 Telemetry::HealthHandle Telemetry::subscribe_health(const HealthCallback& callback)
 {
     return _impl->subscribe_health(callback);

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.h
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.h
@@ -104,6 +104,7 @@ public:
     Telemetry::RawGps raw_gps() const;
     Telemetry::Battery battery() const;
     Telemetry::FlightMode flight_mode() const;
+    Telemetry::VehicleType vehicle_type() const;
     Telemetry::Health health() const;
     bool health_all_ok() const;
     Telemetry::RcStatus rc_status() const;
@@ -170,6 +171,11 @@ public:
     Telemetry::FlightModeHandle
     subscribe_flight_mode(const Telemetry::FlightModeCallback& callback);
     void unsubscribe_flight_mode(Telemetry::FlightModeHandle handle);
+
+    Telemetry::VehicleTypeHandle
+    subscribe_vehicle_type(const Telemetry::VehicleTypeCallback& callback);
+    void unsubscribe_vehicle_type(Telemetry::VehicleTypeHandle handle);
+
     Telemetry::HealthHandle subscribe_health(const Telemetry::HealthCallback& callback);
     void unsubscribe_health(Telemetry::HealthHandle handle);
     Telemetry::HealthAllOkHandle
@@ -312,6 +318,7 @@ private:
     static Telemetry::VtolState to_vtol_state(mavlink_extended_sys_state_t extended_sys_state);
 
     static Telemetry::FlightMode telemetry_flight_mode_from_flight_mode(FlightMode flight_mode);
+    static Telemetry::VehicleType telemetry_vehicle_type_from_MAV_TYPE(MAV_TYPE vehicle_type);
 
     // Make all fields thread-safe using mutexs
     // The mutexs are mutable so that the lock can get aqcuired in
@@ -433,6 +440,7 @@ private:
     CallbackList<Telemetry::RawGps> _raw_gps_subscriptions{};
     CallbackList<Telemetry::Battery> _battery_subscriptions{};
     CallbackList<Telemetry::FlightMode> _flight_mode_subscriptions{};
+    CallbackList<Telemetry::VehicleType> _vehicle_type_subscriptions{};
     CallbackList<Telemetry::Health> _health_subscriptions{};
     CallbackList<bool> _health_all_ok_subscriptions{};
     CallbackList<Telemetry::VtolState> _vtol_state_subscriptions{};


### PR DESCRIPTION
Добавить получение типа аппарата из телеметрии и поддержку всех существующих режимов полета.